### PR TITLE
dom3: fix case where target is a text node

### DIFF
--- a/dom3.js
+++ b/dom3.js
@@ -12,7 +12,7 @@ module.exports = inserted;
 function inserted(el, fn) {
   function cb(mutationEvent) {
     var target = mutationEvent.target
-      , children = [].slice.call(target.getElementsByTagName('*'))
+      , children = target.getElementsByTagName ? [].slice.call(target.getElementsByTagName('*')) : [];
 
     if (el === target || ~children.indexOf(el)) {
       fn(el);


### PR DESCRIPTION
This was throwing on IE when `e.target` was a text node, since text nodes don't have `getElementsByTagName`.
